### PR TITLE
feature/FINP3-7309: Decode UTCTimeStamp fields expressed with microseconds

### DIFF
--- a/compiler/f8c.cpp
+++ b/compiler/f8c.cpp
@@ -85,6 +85,8 @@ e.g.\n
 #include <getopt.h>
 #endif
 
+#include <cstdlib>
+
 //-----------------------------------------------------------------------------------------
 using namespace std;
 using namespace FIX8;
@@ -442,8 +444,10 @@ int main(int argc, char **argv)
 		}
 	}
 
-	if (glob_errors)
+	if (glob_errors) {
 		cerr << glob_errors << " error" << (glob_errors == 1 ? "." : "s.") << endl;
+		exit(1);
+	}
 	if (glob_warnings)
 		cerr << glob_warnings << " warning" << (glob_warnings == 1 ? "." : "s.") << endl;
 	return result;

--- a/compiler/f8c.cpp
+++ b/compiler/f8c.cpp
@@ -4,7 +4,7 @@
 Fix8 is released under the GNU LESSER GENERAL PUBLIC LICENSE Version 3.
 
 Fix8 Open Source FIX Engine.
-Copyright (C) 2010-15 David L. Dight <fix@fix8.org>
+Copyright (C) 2010-19 David L. Dight <fix@fix8.org>
 
 Fix8 is free software: you can  redistribute it and / or modify  it under the  terms of the
 GNU Lesser General  Public License as  published  by the Free  Software Foundation,  either
@@ -96,10 +96,10 @@ const string Ctxt::_exts[count] { "_types.c", "_types.h", "_traits.c", "_classes
 string precompFile, spacer, inputFile, precompHdr, shortName, fixt, shortNameFixt, odir("./"),
        prefix("Myfix"), gen_classes, extra_fields;
 bool verbose(false), error_ignore(false), gen_fields(false), norealm(false), nocheck(false), nowarn(false),
-     incpath(true), nconst_router(false), no_shared_groups(false), no_default_routers(false);
+     incpath(true), nconst_router(false), no_shared_groups(false), no_default_routers(false), report_unused(false);
 unsigned glob_errors(0), glob_warnings(0), tabsize(3), ext_ver(0);
 extern unsigned glob_errors;
-extern const string GETARGLIST("hvVo:p:dikn:rst:x:NRc:fbCIWPF:UeH:SD");
+extern const string GETARGLIST("hvVo:p:dikn:rst:x:NRc:fbCIWPF:UeH:SDu");
 extern string spacer, shortName, precompHdr;
 
 //-----------------------------------------------------------------------------------------
@@ -167,6 +167,7 @@ int main(int argc, char **argv)
 		{ "nocheck",		0,	0,	'C' },
 		{ "noconst",		0,	0,	'U' },
 		{ "info",		   0,	0,	'I' },
+		{ "unused",		   0,	0,	'u' },
 		{ "fields",			0,	0,	'f' },
 		{ "xfields",		1,	0,	'F' },
 		{ "keep",			0,	0,	'k' },
@@ -204,6 +205,7 @@ int main(int argc, char **argv)
 		case 'R': norealm = true; break;
 		case 'C': nocheck = true; break;
 		case 'U': nconst_router = true; break;
+		case 'u': report_unused = true; break;
 		case 'c': gen_classes = optarg; break;
 		case 'F': extra_fields = optarg; break;
 		case 'h': print_usage(); return 0;
@@ -328,6 +330,12 @@ int main(int argc, char **argv)
 
 	if (load_fix_version (*cfr, ctxt) < 0)
 		return 1;
+   if (ctxt._beginstr.compare(0, 4, "FIX.") == 0 && ctxt._version >= 5000)
+   {
+      cerr << "Error: " << ctxt._beginstr << " requires an additional FIXT schema specification." << endl;
+      return 1;
+   }
+
 	for (unsigned ii(0); ii < Ctxt::count; ++ii)
 	{
 		ctxt._out[ii].first.second = prefix + ctxt._exts[ii] + ctxt._exts_ver[ext_ver];
@@ -466,11 +474,21 @@ int load_fields(XmlElement& xf, FieldSpecMap& fspec)
 			FieldTrait::FieldType ft(bmitr == FieldSpec::_baseTypeMap.end() ? FieldTrait::ft_untyped : bmitr->second);
 			pair<FieldSpecMap::iterator, bool> result;
 			if (ft != FieldTrait::ft_untyped)
-				result = fspec.insert({stoul(number), FieldSpec(name, ft)});
-			else
-			{
-            if (!nowarn)
-               cerr << shortName << ':' << recover_line(*pp) << ": warning: Unknown field type: " << type << " in " << name << endl;
+         {
+				try
+            {
+					result = fspec.insert({stoul(number), FieldSpec(name, ft)});
+				}
+            catch (exception& e)
+            {
+					cerr << shortName << ':' << recover_line(*pp) << ": error: Failed to convert (stoul) number " << number << " in " << name << endl;
+					++glob_errors;
+				}
+			}
+         else
+         {
+				if (!nowarn)
+					cerr << shortName << ':' << recover_line(*pp) << ": warning: Unknown field type: " << type << " in " << name << endl;
 				++glob_warnings;
 				continue;
 			}
@@ -1412,12 +1430,16 @@ int process(XmlElement& xf, Ctxt& ctxt)
 	ost_cpp << "extern const " << ctxt._clname << "_BaseEntry::Pair fldpairs[];" << endl;
 	ost_cpp << "const " << ctxt._clname << "_BaseEntry::Pair fldpairs[] "
       << endl << '{' << endl;
+   FieldSpecMap::const_iterator fromfitr(fspec.begin());
 	for (FieldSpecMap::const_iterator fitr(fspec.begin()); fitr != fspec.end(); ++fitr)
 	{
 		if (!gen_fields && !fitr->second._used)
-			continue;
-		if (fitr != fspec.begin())
-			ost_cpp << ',' << endl;
+      {
+         ++fromfitr;
+         continue;
+      }
+      if (fitr != fromfitr)
+         ost_cpp << ',' << endl;
 		ost_cpp << spacer << "{ " << fitr->first << ", { ";
 		if (fitr->second._dvals && !norealm) // generate code to create a Field using a value taken from an index into a Realm
 		{
@@ -1457,10 +1479,22 @@ int process(XmlElement& xf, Ctxt& ctxt)
 
 	if (verbose)
 	{
-		unsigned cnt(0);
+		unsigned cnt(0), ucnt(0);
 		for (const auto& pp : fspec)
+      {
 			if (pp.second._used)
 				++cnt;
+         else if (report_unused)
+         {
+            if (ucnt++)
+               cout << ',';
+            else
+               cout << "Unused fields: ";
+            cout << pp.second._name << '(' << pp.first << ')';
+         }
+      }
+      if (report_unused && ucnt)
+         cout << endl;
 		cout << cnt << " of " << fspec.size() << " fields used in messages" << endl;
 	}
 

--- a/compiler/f8c.hpp
+++ b/compiler/f8c.hpp
@@ -171,6 +171,7 @@ struct MessageSpec
 	    \return stream */
 	friend std::ostream& operator<<(std::ostream& os, const MessageSpec& what);
 };
+std::ostream& operator<<(std::ostream& os, const MessageSpec& what);
 
 using MessageSpecMap = std::map<const std::string, MessageSpec>;
 using FieldTraitOrder = std::multiset<const FieldTrait *, FieldTrait::PosCompare>;

--- a/compiler/f8c.hpp
+++ b/compiler/f8c.hpp
@@ -4,7 +4,7 @@
 Fix8 is released under the GNU LESSER GENERAL PUBLIC LICENSE Version 3.
 
 Fix8 Open Source FIX Engine.
-Copyright (C) 2010-15 David L. Dight <fix@fix8.org>
+Copyright (C) 2010-19 David L. Dight <fix@fix8.org>
 
 Fix8 is free software: you can  redistribute it and / or modify  it under the  terms of the
 GNU Lesser General  Public License as  published  by the Free  Software Foundation,  either
@@ -171,7 +171,6 @@ struct MessageSpec
 	    \return stream */
 	friend std::ostream& operator<<(std::ostream& os, const MessageSpec& what);
 };
-std::ostream& operator<<(std::ostream& os, const MessageSpec& what);
 
 using MessageSpecMap = std::map<const std::string, MessageSpec>;
 using FieldTraitOrder = std::multiset<const FieldTrait *, FieldTrait::PosCompare>;

--- a/compiler/f8c.hpp
+++ b/compiler/f8c.hpp
@@ -171,7 +171,6 @@ struct MessageSpec
 	    \return stream */
 	friend std::ostream& operator<<(std::ostream& os, const MessageSpec& what);
 };
-std::ostream& operator<<(std::ostream& os, const MessageSpec& what);
 
 using MessageSpecMap = std::map<const std::string, MessageSpec>;
 using FieldTraitOrder = std::multiset<const FieldTrait *, FieldTrait::PosCompare>;

--- a/compiler/f8c.hpp
+++ b/compiler/f8c.hpp
@@ -156,7 +156,7 @@ struct MessageSpec
 {
 	FieldTraits _fields;
 	GroupMap _groups;
-   uint32_t _group_refcnt, _hash;
+	uint32_t _group_refcnt, _hash;
 	std::string _name, _description, _comment;
 	bool _is_admin;
 
@@ -171,6 +171,7 @@ struct MessageSpec
 	    \return stream */
 	friend std::ostream& operator<<(std::ostream& os, const MessageSpec& what);
 };
+std::ostream& operator<<(std::ostream& os, const MessageSpec& what);
 
 using MessageSpecMap = std::map<const std::string, MessageSpec>;
 using FieldTraitOrder = std::multiset<const FieldTrait *, FieldTrait::PosCompare>;

--- a/compiler/f8cstatic.hpp
+++ b/compiler/f8cstatic.hpp
@@ -4,7 +4,7 @@
 Fix8 is released under the GNU LESSER GENERAL PUBLIC LICENSE Version 3.
 
 Fix8 Open Source FIX Engine.
-Copyright (C) 2010-15 David L. Dight <fix@fix8.org>
+Copyright (C) 2010-19 David L. Dight <fix@fix8.org>
 
 Fix8 is free software: you can  redistribute it and / or modify  it under the  terms of the
 GNU Lesser General  Public License as  published  by the Free  Software Foundation,  either

--- a/compiler/f8cutils.cpp
+++ b/compiler/f8cutils.cpp
@@ -4,7 +4,7 @@
 Fix8 is released under the GNU LESSER GENERAL PUBLIC LICENSE Version 3.
 
 Fix8 Open Source FIX Engine.
-Copyright (C) 2010-15 David L. Dight <fix@fix8.org>
+Copyright (C) 2010-19 David L. Dight <fix@fix8.org>
 
 Fix8 is free software: you can  redistribute it and / or modify  it under the  terms of the
 GNU Lesser General  Public License as  published  by the Free  Software Foundation,  either
@@ -341,6 +341,7 @@ void print_usage()
 	um.add('C', "nocheck", "do not embed version checking in generated code (default false)");
 	um.add('D', "defaulted", "do not generate default router bodies. Application must provide all router definitions (default false)");
 	um.add('U', "noconst", "Generate non-const Router method declarations (default false, const)");
+	um.add('u', "unused", "Report unused fields, requires verbose option (default false)");
 	um.add('r', "retain", "retain 1st pass code (default delete)");
 	um.add('b', "binary", "print binary/ABI details, exit");
 	um.add('P', "incpath", "prefix system include path with \"fix8\" in generated compilation units (default yes)");

--- a/compiler/f8cutils.cpp
+++ b/compiler/f8cutils.cpp
@@ -233,7 +233,7 @@ int process_message_fields(const std::string& where, const XmlElement *xt, Field
 				FieldSpecMap::iterator fs_itr;
 				if (ftonItr == ftonSpec.end() || (fs_itr = fspec.find(ftonItr->second)) == fspec.end())
 				{
-					cerr << shortName << ':' << recover_line(*pp) << ": error: Field element missing required attributes" << endl;
+					cerr << shortName << ':' << recover_line(*pp) << ": error: Field named: " << fname << " missing required attributes" << endl;
 					++glob_errors;
 					continue;
 				}
@@ -257,7 +257,7 @@ int process_message_fields(const std::string& where, const XmlElement *xt, Field
 			}
 			else
 			{
-				cerr << shortName << ':' << recover_line(*pp) << ": error: Field element missing required attributes" << endl;
+				cerr << shortName << ':' << recover_line(*pp) << ": error: Field named: " << fname << " missing required attributes" << endl;
 				++glob_errors;
 			}
 		}

--- a/compiler/f8precomp.cpp
+++ b/compiler/f8precomp.cpp
@@ -159,12 +159,38 @@ int precompfixt(XmlElement& xft, XmlElement& xf, ostream& outf, bool nounique)
 	return 0;
 }
 
+void assertNoDuplicatesWithDifferentNamesButSameId(XmlElement::XmlSet& fldlist) {
+	//ig addition: find out whether there is duplicated name that has different number
+	for(auto outerIt = fldlist.begin(); outerIt != fldlist.end(); ++outerIt) {
+		auto &a = *outerIt;
+		std::string numA, nameA;
+		a->GetAttr("number", numA);
+		a->GetAttr("name", nameA);
+		for(auto innerIt = fldlist.begin(); innerIt != outerIt; ++innerIt) {
+
+			auto &b = *innerIt;
+			std::string numB, nameB;
+
+			b->GetAttr("number", numB);
+			b->GetAttr("name", nameB);
+
+			if(numA == numB && nameA != nameB) {
+				printf("found duplicated numbers: %s(%s) and %s(%s)", nameA.c_str(), numA.c_str(), nameB.c_str(), numB.c_str());
+				std::abort();
+			}
+		}
+	}
+}
+
 //-----------------------------------------------------------------------------------------
 void filter_unique(XmlElement::XmlSet& fldlist)
 {
+	assertNoDuplicatesWithDifferentNamesButSameId(fldlist);
+
 	using UniqueFieldMap = map<string, const XmlElement *>;
 	UniqueFieldMap ufm;
 	unsigned dupls(0);
+
 	for(const auto *pp : fldlist)
 	{
 		string name;

--- a/compiler/f8precomp.cpp
+++ b/compiler/f8precomp.cpp
@@ -4,7 +4,7 @@
 Fix8 is released under the GNU LESSER GENERAL PUBLIC LICENSE Version 3.
 
 Fix8 Open Source FIX Engine.
-Copyright (C) 2010-15 David L. Dight <fix@fix8.org>
+Copyright (C) 2010-19 David L. Dight <fix@fix8.org>
 
 Fix8 is free software: you can  redistribute it and / or modify  it under the  terms of the
 GNU Lesser General  Public License as  published  by the Free  Software Foundation,  either

--- a/compiler/precomp.cpp
+++ b/compiler/precomp.cpp
@@ -4,7 +4,7 @@
 Fix8 is released under the GNU LESSER GENERAL PUBLIC LICENSE Version 3.
 
 Fix8 Open Source FIX Engine.
-Copyright (C) 2010-15 David L. Dight <fix@fix8.org>
+Copyright (C) 2010-19 David L. Dight <fix@fix8.org>
 
 Fix8 is free software: you can  redistribute it and / or modify  it under the  terms of the
 GNU Lesser General  Public License as  published  by the Free  Software Foundation,  either

--- a/include/fix8/connection.hpp
+++ b/include/fix8/connection.hpp
@@ -130,6 +130,7 @@ class FIXReader : public AsyncSocket<f8String>
 {
 	enum { _max_msg_len = FIX8_MAX_MSG_LENGTH, _chksum_sz = 7 };
 	f8_atomic<bool> _socket_error;
+	f8_mutex _join_mutex;
 
 	f8_thread<FIXReader> _callback_thread;
 	f8_thread_cancellation_token _callback_cancellation_token;
@@ -299,7 +300,15 @@ public:
 
 	/*! Wait till writer thread has finished.
 		 \return 0 on success */
-	int join() { return _pmodel != pm_coro ? AsyncSocket<f8String>::join() : -1; }
+	int join()
+	{
+		if (_pmodel != pm_coro)
+		{
+			f8_scoped_lock guard(_join_mutex);
+			return AsyncSocket<f8String>::join();
+		}
+		return -1;
+	}
 
 	/// Calculate the length of the Fix message preamble, e.g. "8=FIX.4.4^A9=".
 	F8API void set_preamble_sz();

--- a/include/fix8/connection.hpp
+++ b/include/fix8/connection.hpp
@@ -339,6 +339,12 @@ public:
 		quit();
 	}
 
+	bool write_raw(std::function<std::size_t(const Header&, const char*)> encode, const char* buffer)
+	{
+		f8_scoped_spin_lock guard(_con_spl);
+		return _session.send_raw_process(encode, buffer);
+	}
+
 	/*! Place Fix message on outbound message queue.
 	    \param from message to send
 	    \param destroy if true delete after send
@@ -566,6 +572,11 @@ public:
 	    \param from Message to write
 	    \return true on success */
 	virtual bool write(Message& from) { return _writer.write(from); }
+
+	bool write_raw(std::function<std::size_t(const Header&, const char*)> encode, const char* buffer)
+	{
+		return _writer.write_raw(encode, buffer);
+	}
 
 	/*! Write messages to the underlying socket as a single batch.
 	    \param msgs vector of Message to write

--- a/include/fix8/connection.hpp
+++ b/include/fix8/connection.hpp
@@ -300,15 +300,7 @@ public:
 
 	/*! Wait till writer thread has finished.
 		 \return 0 on success */
-	int join()
-	{
-		if (_pmodel != pm_coro)
-		{
-			f8_scoped_lock guard(_join_mutex);
-			return AsyncSocket<f8String>::join();
-		}
-		return -1;
-	}
+	int join() { return _pmodel != pm_coro ? AsyncSocket<f8String>::join() : -1; }
 
 	/// Calculate the length of the Fix message preamble, e.g. "8=FIX.4.4^A9=".
 	F8API void set_preamble_sz();

--- a/include/fix8/connection.hpp
+++ b/include/fix8/connection.hpp
@@ -534,7 +534,7 @@ public:
 		  _secured(secured) {}
 
 	/// Dtor.
-  virtual ~Connection() { _session.clear_connection(this); }
+	virtual ~Connection() { _session.clear_connection(this); }
 
 	/*! Get the role for this connection.
 	    \return the role */

--- a/include/fix8/connection.hpp
+++ b/include/fix8/connection.hpp
@@ -339,11 +339,11 @@ public:
 		quit();
 	}
 
-    bool write_raw(std::function<std::size_t(const Header&)> encode, const char* buffer)
-    {
-        f8_scoped_spin_lock guard(_con_spl);
-        return _session.send_raw_process(encode, buffer);
-    }
+	bool write_raw(const std::function<std::size_t(const Header&)>& encode, const char* buffer)
+	{
+		f8_scoped_spin_lock guard(_con_spl);
+		return _session.send_raw_process(encode, buffer);
+	}
 
 	/*! Place Fix message on outbound message queue.
 	    \param from message to send
@@ -573,10 +573,10 @@ public:
 	    \return true on success */
 	virtual bool write(Message& from) { return _writer.write(from); }
 
-    bool write_raw(std::function<std::size_t(const Header&)> encode, const char* buffer)
-    {
-        return _writer.write_raw(encode, buffer);
-    }
+	bool write_raw(std::function<std::size_t(const Header&)> encode, const char* buffer)
+	{
+		return _writer.write_raw(encode, buffer);
+	}
 
 	/*! Write messages to the underlying socket as a single batch.
 	    \param msgs vector of Message to write

--- a/include/fix8/connection.hpp
+++ b/include/fix8/connection.hpp
@@ -130,7 +130,6 @@ class FIXReader : public AsyncSocket<f8String>
 {
 	enum { _max_msg_len = FIX8_MAX_MSG_LENGTH, _chksum_sz = 7 };
 	f8_atomic<bool> _socket_error;
-	f8_mutex _join_mutex;
 
 	f8_thread<FIXReader> _callback_thread;
 	f8_thread_cancellation_token _callback_cancellation_token;

--- a/include/fix8/connection.hpp
+++ b/include/fix8/connection.hpp
@@ -339,11 +339,11 @@ public:
 		quit();
 	}
 
-	bool write_raw(std::function<std::size_t(const Header&, const char*)> encode, const char* buffer)
-	{
-		f8_scoped_spin_lock guard(_con_spl);
-		return _session.send_raw_process(encode, buffer);
-	}
+    bool write_raw(std::function<std::size_t(const Header&)> encode, const char* buffer)
+    {
+        f8_scoped_spin_lock guard(_con_spl);
+        return _session.send_raw_process(encode, buffer);
+    }
 
 	/*! Place Fix message on outbound message queue.
 	    \param from message to send
@@ -573,10 +573,10 @@ public:
 	    \return true on success */
 	virtual bool write(Message& from) { return _writer.write(from); }
 
-	bool write_raw(std::function<std::size_t(const Header&, const char*)> encode, const char* buffer)
-	{
-		return _writer.write_raw(encode, buffer);
-	}
+    bool write_raw(std::function<std::size_t(const Header&)> encode, const char* buffer)
+    {
+        return _writer.write_raw(encode, buffer);
+    }
 
 	/*! Write messages to the underlying socket as a single batch.
 	    \param msgs vector of Message to write

--- a/include/fix8/field.hpp
+++ b/include/fix8/field.hpp
@@ -1156,6 +1156,11 @@ public:
 	/* \param from field to copy */
 	Field (const Field& from) : BaseField(field), _value(from._value) {}
 
+	/*! Value ctor.
+	  \param val value to set
+	  \param rlm pointer to the realmbase for this field (if available) */
+	explicit Field (const Tickval& val, const RealmBase *rlm=nullptr) : BaseField(field, rlm), _value(val) {}
+
 	/*! Construct from string ctor.
 	  \param from string to construct field from
 	  \param rlm pointer to the realmbase for this field (if available) */
@@ -1258,6 +1263,11 @@ public:
 	/// Copy Ctor.
 	/* \param from field to copy */
 	Field (const Field& from) : BaseField(field), _value(from._value) {}
+
+	/*! Value ctor.
+	  \param val value to set
+	  \param rlm pointer to the realmbase for this field (if available) */
+	explicit Field (const Tickval& val, const RealmBase *rlm=nullptr) : BaseField(field, rlm), _value(val) {}
 
 	/*! Construct from string ctor.
 	  \param from string to construct field from
@@ -1362,6 +1372,11 @@ public:
 	/* \param from field to copy */
 	Field (const Field& from) : BaseField(field), _value(from._value) {}
 
+	/*! Value ctor.
+	  \param val value to set
+	  \param rlm pointer to the realmbase for this field (if available) */
+	explicit Field (const Tickval& val, const RealmBase *rlm=nullptr) : BaseField(field, rlm), _value(val) {}
+
 	/*! Construct from string ctor.
 	  \param from string to construct field from
 	  \param rlm pointer to the realmbase for this field (if available) */
@@ -1465,6 +1480,11 @@ public:
 	/// Copy Ctor.
 	/* \param from field to copy */
 	Field (const Field& from) : BaseField(field), _sz(from._sz), _value(from._value) {}
+
+	/*! Value ctor.
+	  \param val value to set
+	  \param rlm pointer to the realmbase for this field (if available) */
+	explicit Field (const Tickval& val, const RealmBase *rlm=nullptr) : BaseField(field, rlm), _sz(6) _value(val) {}
 
 	/*! Construct from string ctor.
 	  \param from string to construct field from

--- a/include/fix8/field.hpp
+++ b/include/fix8/field.hpp
@@ -873,7 +873,10 @@ inline time_t time_to_epoch (const tm& ltm, int utcdiff=0)
    };
 
    const int tyears(ltm.tm_year ? ltm.tm_year - 70 : 0); // tm->tm_year is from 1900.
-   const int tdays(mon_days[ltm.tm_mon] + (ltm.tm_mday ? ltm.tm_mday - 1 : 0) + tyears * 365 + (tyears + 2) / 4);
+   int leaps((tyears + 2) / 4);
+   if ((((tyears + 2) % 4) == 0) && (ltm.tm_mon < 2)) // move epoch from end of dec to end to feb on leap years
+      --leaps;
+   const int tdays(mon_days[ltm.tm_mon] + (ltm.tm_mday ? ltm.tm_mday - 1 : 0) + tyears * 365 + leaps);
    return tdays * 86400 + (ltm.tm_hour + utcdiff) * 3600 + ltm.tm_min * 60 + ltm.tm_sec;
 }
 

--- a/include/fix8/logger.hpp
+++ b/include/fix8/logger.hpp
@@ -357,9 +357,14 @@ public:
 /// A file logger.
 class FileLogger : public Logger
 {
+public:
+	typedef std::streamoff streamoff_type;
+
 protected:
 	std::string _pathname;
 	unsigned _rotnum;
+	streamoff_type _rotsize;
+	f8_mutex _rotsize_mutex;
 
 public:
 	/*! Ctor.
@@ -370,7 +375,8 @@ public:
 	    \param positions field positions
 	    \param rotnum number of logfile rotations to retain (default=5) */
 	F8API FileLogger(const std::string& pathname, const LogFlags flags, const Levels levels, const std::string delim=" ",
-		const LogPositions positions=LogPositions(), const unsigned rotnum=rotation_default);
+		const LogPositions positions=LogPositions(), const unsigned rotnum=rotation_default,
+		streamoff_type rotsize=std::numeric_limits<streamoff_type>::max());
 
 	/// Dtor.
 	virtual ~FileLogger() {}
@@ -379,13 +385,19 @@ public:
 	    \param force force the rotation (even if the file is set ti append)
 	    \return true on success */
 	F8API virtual bool rotate(bool force=false);
+
+	/*! Process this logelement
+	    \param le LogElement */
+	F8API virtual void process_logline(LogElement *le);
+
+	/// Return rotate size threshold
+	streamoff_type get_rotate_size() const { return _rotsize; }
 };
 
 //-------------------------------------------------------------------------------------------------
 /// A file logger.
 class XmlFileLogger : public FileLogger
 {
-
 public:
 	/*! Ctor.
 	    \param pathname pathname to log to
@@ -395,8 +407,9 @@ public:
 	    \param positions field positions
 	    \param rotnum number of logfile rotations to retain (default=5) */
 	F8API XmlFileLogger(const std::string& pathname, const LogFlags flags, const Levels levels, const std::string delim=" ",
-		const LogPositions positions=LogPositions(), const unsigned rotnum=rotation_default)
-		: FileLogger(pathname, flags, levels, delim, positions, rotnum)
+		const LogPositions positions=LogPositions(), const unsigned rotnum=rotation_default,
+		streamoff_type rotsize=std::numeric_limits<streamoff_type>::max())
+		: FileLogger(pathname, flags, levels, delim, positions, rotnum, rotsize)
 	{
 		preamble();
 	}

--- a/include/fix8/logger.hpp
+++ b/include/fix8/logger.hpp
@@ -39,6 +39,7 @@ HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 
 //-------------------------------------------------------------------------------------------------
 #include <list>
+#include <functional>
 #include <Poco/Net/IPAddress.h>
 #include <Poco/Net/DatagramSocket.h>
 

--- a/include/fix8/logger.hpp
+++ b/include/fix8/logger.hpp
@@ -364,8 +364,6 @@ protected:
 	std::string _pathname;
 	unsigned _rotnum;
 	streamoff_type _rotsize;
-	f8_mutex _rotsize_mutex;
-
 public:
 	/*! Ctor.
 	    \param pathname pathname to log to
@@ -392,6 +390,10 @@ public:
 
 	/// Return rotate size threshold
 	streamoff_type get_rotate_size() const { return _rotsize; }
+
+	/// Return current file size
+	/// note that by the time you read the value returned by this function real size might have already changed.
+	streamoff_type get_current_file_size() const;
 };
 
 //-------------------------------------------------------------------------------------------------

--- a/include/fix8/message.hpp
+++ b/include/fix8/message.hpp
@@ -1141,7 +1141,9 @@ public:
 	    \return calculated checknum */
 	static unsigned calc_chksum(const char *from, const size_t sz, const unsigned offset=0, const int len=-1)
 	{
-#if defined FIX8_SIZEOF_UNSIGNED_LONG && FIX8_SIZEOF_UNSIGNED_LONG == 8
+// steroid checksum disabled as its bugged for large messages.
+//#if defined FIX8_SIZEOF_UNSIGNED_LONG && FIX8_SIZEOF_UNSIGNED_LONG == 8
+#if 0
 		// steroid chksum algorithm by charles.cooper@lambda-tg.com
 		// Basic strategy is to unroll the loop. normally adding in a loop
 		// is slow because of the dependency, the cpu has to finish each loop

--- a/include/fix8/session.hpp
+++ b/include/fix8/session.hpp
@@ -192,6 +192,7 @@ namespace defaults
 		hb_interval=30,
 		connect_timeout=10,
 		log_rotation=5,
+		log_rotate_size=std::numeric_limits<std::streamoff>::max(),
 		verification_depth=9
 	};
 }

--- a/include/fix8/session.hpp
+++ b/include/fix8/session.hpp
@@ -385,11 +385,11 @@ struct Session_Schedule
 };
 
 struct Header {
-    const char* version;
-    const char* sender;
-    const char* target;
-    const char* sending_time;
-    unsigned seqno;
+	const char* version;
+	const char* sender;
+	const char* target;
+	const char* sending_time;
+	unsigned seqno;
 };
 
 //-------------------------------------------------------------------------------------------------
@@ -645,9 +645,9 @@ public:
 	 			with the reamining messages in the vector still allocated */
 	F8API virtual size_t send_batch(const std::vector<Message *>& msgs, bool destroy=true);
 
-    F8API bool send_raw(std::function<std::size_t(const Header&)> encode, char* buffer);
+	F8API bool send_raw(const std::function<std::size_t(const Header&)>& encode, char* buffer);
 
-    F8API bool send_raw_process(std::function<std::size_t(const Header&)>, const char*);
+	F8API bool send_raw_process(const std::function<std::size_t(const Header&)>&, const char*);
 
 	/*! Process message (encode) and send.
 	    \param msg Message

--- a/include/fix8/session.hpp
+++ b/include/fix8/session.hpp
@@ -384,6 +384,14 @@ struct Session_Schedule
 	}
 };
 
+struct Header {
+    const char* version;
+    const char* sender;
+    const char* target;
+    const char* sending_time;
+    unsigned seqno;
+};
+
 //-------------------------------------------------------------------------------------------------
 class Persister;
 class Logger;
@@ -636,6 +644,10 @@ public:
 	    \return size_t number of messages sent - if destroy was true those sent messages will have been destroyed
 	 			with the reamining messages in the vector still allocated */
 	F8API virtual size_t send_batch(const std::vector<Message *>& msgs, bool destroy=true);
+
+    F8API bool send_raw(std::function<std::size_t(const Header&, const char*)> encode, char* buffer);
+
+	F8API bool send_raw_process(std::function<std::size_t(const Header&, const char*)>, const char*);
 
 	/*! Process message (encode) and send.
 	    \param msg Message

--- a/include/fix8/session.hpp
+++ b/include/fix8/session.hpp
@@ -645,9 +645,9 @@ public:
 	 			with the reamining messages in the vector still allocated */
 	F8API virtual size_t send_batch(const std::vector<Message *>& msgs, bool destroy=true);
 
-    F8API bool send_raw(std::function<std::size_t(const Header&, const char*)> encode, char* buffer);
+    F8API bool send_raw(std::function<std::size_t(const Header&)> encode, char* buffer);
 
-	F8API bool send_raw_process(std::function<std::size_t(const Header&, const char*)>, const char*);
+    F8API bool send_raw_process(std::function<std::size_t(const Header&)>, const char*);
 
 	/*! Process message (encode) and send.
 	    \param msg Message

--- a/include/fix8/thread.hpp
+++ b/include/fix8/thread.hpp
@@ -103,6 +103,7 @@ public:
 		if (pthread_attr_init(&_attr))
 			throw f8_threadException("pthread_attr_init failure");
 #else
+		: _thread_ptr(nullptr)
 	{
 #endif
 	}

--- a/include/fix8/thread.hpp
+++ b/include/fix8/thread.hpp
@@ -51,8 +51,7 @@ HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 //----------------------------------------------------------------------------------------
 namespace FIX8
 {
-
-template<typename T> using f8_atomic = std::atomic <T>;
+template<typename T> using f8_atomic = std::atomic<T>;
 
 #if (FIX8_THREAD_SYSTEM == FIX8_THREAD_STDTHREAD)
 	using thread_id_t = std::thread::id;
@@ -68,7 +67,7 @@ class _f8_threadcore
 	pthread_attr_t _attr;
 	pthread_t _tid;
 #elif (FIX8_THREAD_SYSTEM == FIX8_THREAD_STDTHREAD)
-	std::atomic<std::thread*> _thread_ptr;
+	std::atomic<std::thread*> _thread_ptr{nullptr};
 #endif
 
 #if (FIX8_THREAD_SYSTEM == FIX8_THREAD_PTHREAD)
@@ -77,6 +76,30 @@ class _f8_threadcore
 #else
 	template<typename T>
 	static void _run(void *what) { (*static_cast<T *>(what))(); }
+#endif
+
+#if (FIX8_THREAD_SYSTEM == FIX8_THREAD_STDTHREAD)
+	int _join(std::thread* thread_ptr)
+	{
+		if (thread_ptr)
+		{
+			if (thread_ptr->get_id() == std::thread::id())
+				return -2;	// possibly already joined
+			if (thread_ptr->get_id() == std::this_thread::get_id())
+				return -1;	// join on self
+			try
+			{
+				thread_ptr->join();
+				delete thread_ptr;
+			}
+			catch (const std::system_error &e)
+			{
+				std::string str{"_f8_threadcore::_join: " + std::string(e.what())};
+				throw std::logic_error(std::move(str));
+			}
+		}
+		return 0;
+	}
 #endif
 
 protected:
@@ -88,16 +111,7 @@ protected:
 #elif (FIX8_THREAD_SYSTEM == FIX8_THREAD_STDTHREAD)
 		if (std::thread* thread_ptr = _thread_ptr.exchange(new std::thread(_run<T>, sub)))
 		{
-			try
-			{
-				thread_ptr->join();
-				delete thread_ptr;
-			}
-			catch (const std::system_error &) {
-				std::string str("_f8_threadcore::_start: join called on a joined thread");
-				throw std::logic_error(std::move(str));
-			}
-			throw std::logic_error("_f8_threadcore::_start called on an active thread");
+			return _join(thread_ptr);
 		}
 #endif
 		return 0;
@@ -112,7 +126,6 @@ public:
 		if (pthread_attr_init(&_attr))
 			throw f8_threadException("pthread_attr_init failure");
 #else
-		: _thread_ptr(nullptr)
 	{
 #endif
 	}
@@ -120,7 +133,7 @@ public:
 	/// Dtor.
 	virtual ~_f8_threadcore()
 	{
-	  join();
+		join();
 #if (FIX8_THREAD_SYSTEM == FIX8_THREAD_PTHREAD)
 		pthread_attr_destroy(&_attr);
 #endif
@@ -143,15 +156,7 @@ public:
 #elif (FIX8_THREAD_SYSTEM == FIX8_THREAD_STDTHREAD)
 		if (std::thread* thread_ptr = _thread_ptr.exchange(nullptr))
 		{
-			try
-			{
-				thread_ptr->join();
-				delete thread_ptr;
-			}
-			catch (const std::system_error &) {
-				std::string str("_f8_threadcore::join: join called on a joined thread");
-				throw std::logic_error(std::move(str));
-			}
+			return _join(thread_ptr);
 		}
 
 		return 0;
@@ -415,11 +420,11 @@ class f8_spin_lock
 
 public:
     f8_spin_lock()
-	 {
+	{
 #ifdef _MSC_VER
 		 _sl.clear(std::memory_order_relaxed); // = ATOMIC_FLAG_INIT # does not compile under vs2013
 #endif
-	 }
+	}
 	~f8_spin_lock() = default;
 
 	void lock() { while (!try_lock()); }

--- a/include/fix8/thread.hpp
+++ b/include/fix8/thread.hpp
@@ -83,8 +83,6 @@ class _f8_threadcore
 	{
 		if (thread_ptr)
 		{
-			if (thread_ptr->get_id() == std::thread::id())
-				return -2;	// possibly already joined
 			if (thread_ptr->get_id() == std::this_thread::get_id())
 				return -1;	// join on self
 			try
@@ -111,7 +109,7 @@ protected:
 #elif (FIX8_THREAD_SYSTEM == FIX8_THREAD_STDTHREAD)
 		if (std::thread* thread_ptr = _thread_ptr.exchange(new std::thread(_run<T>, sub)))
 		{
-			return _join(thread_ptr);
+			std::terminate();
 		}
 #endif
 		return 0;

--- a/include/fix8/tickval.hpp
+++ b/include/fix8/tickval.hpp
@@ -134,6 +134,11 @@ public:
 		return *this;
 	}
 
+        /* Returns internal value, usually thats std::chrono::system_clock::time_point */
+        f8_time_point value() const {
+		return _value;
+	}
+
 	/*! Get the current number of elapsed seconds
 	  \return value in seconds */
 	time_t secs() const { return std::chrono::duration_cast<std::chrono::seconds>(_value.time_since_epoch()).count(); }

--- a/include/fix8/traits.hpp
+++ b/include/fix8/traits.hpp
@@ -209,6 +209,9 @@ struct FieldTrait_Hash_Array
    }
 
    ~FieldTrait_Hash_Array() { delete[] _arr; }
+
+   FieldTrait_Hash_Array(const FieldTrait_Hash_Array &) = delete;
+   FieldTrait_Hash_Array& operator=(const FieldTrait_Hash_Array &) = delete;
 };
 
 //-------------------------------------------------------------------------------------------------
@@ -235,10 +238,11 @@ public:
 	}
 
 private:
-	size_t _reserve;
-	size_t _sz, _rsz;
-	FieldTrait *_arr;
-	const FieldTrait_Hash_Array *_ftha;
+	size_t _reserve = 0;
+	size_t _sz = 0;
+	size_t _rsz = 0;
+	FieldTrait *_arr = nullptr;
+	const FieldTrait_Hash_Array *_ftha = nullptr;
 
 	using internal_result = std::pair<iterator, iterator>;
 	using const_internal_result = std::pair<const_iterator, const_iterator>;
@@ -249,31 +253,49 @@ public:
 	  \param sz number of elements in set to copy
 	  \param ftha pointer to field hash array */
 	presorted_set(const_iterator arr_start, const size_t sz, const FieldTrait_Hash_Array *ftha)
-		: _reserve(), _sz(sz), _arr(new FieldTrait[_sz]), _ftha(ftha)
+		: _sz(sz), _arr(new FieldTrait[_sz]), _ftha(ftha)
 			{ memcpy(_arr, arr_start, _sz * sizeof(FieldTrait)); }
 
 	/*! ctor - initialise an empty set; defer memory allocation;
 	  \param arr_start pointer to start of static array to copy elements from
 	  \param sz number of elements to initially allocate
 	  \param reserve percentage of sz to keep in reserve */
-	presorted_set(const_iterator arr_start, const size_t sz, const size_t reserve=FIX8_RESERVE_PERCENT) : _reserve(reserve),
-		_sz(sz), _rsz(_sz + calc_reserve(_sz, _reserve)), _arr(new FieldTrait[_rsz]), _ftha()
+	presorted_set(const_iterator arr_start, const size_t sz, const size_t reserve=FIX8_RESERVE_PERCENT)
+		: _reserve(reserve), _sz(sz), _rsz(_sz + calc_reserve(_sz, _reserve)), _arr(new FieldTrait[_rsz])
 			{ memcpy(_arr, arr_start, _sz * sizeof(FieldTrait)); }
 
 	/*! copy ctor
 	  \param from presorted_set object to copy */
-	presorted_set(const presorted_set& from) : _reserve(from._reserve),
-		_sz(from._sz), _rsz(from._rsz), _arr(new FieldTrait[_rsz]), _ftha(from._ftha)
+	presorted_set(const presorted_set& from)
+		: _reserve(from._reserve), _sz(from._sz), _rsz(from._rsz), _arr(new FieldTrait[_rsz]), _ftha(from._ftha)
 			{ memcpy(_arr, from._arr, _sz * sizeof(FieldTrait)); }
 
 	/*! ctor - initialise an empty set; defer memory allocation;
 	  \param sz number of elements to initially allocate
 	  \param reserve percentage of sz to keep in reserve */
-	explicit presorted_set(const size_t sz=0, const size_t reserve=FIX8_RESERVE_PERCENT) : _reserve(reserve),
-		_sz(sz), _rsz(_sz + calc_reserve(_sz, _reserve)), _arr(), _ftha() {}
+	explicit presorted_set(const size_t sz=0, const size_t reserve=FIX8_RESERVE_PERCENT)
+		: _reserve(reserve), _sz(sz), _rsz(_sz + calc_reserve(_sz, _reserve)) {}
 
 	/// dtor
 	~presorted_set() { delete[] _arr; }
+
+	presorted_set& operator=(const presorted_set& from) {
+		if (this != &from) {
+			presorted_set tmp(from);
+			swap(tmp);
+		}
+		return *this;
+	}
+
+	void swap(presorted_set& from) {
+		if (this != &from) {
+			std::swap(_reserve, from._reserve);
+			std::swap(_sz, from._sz);
+			std::swap(_rsz, from._rsz);
+			std::swap(_arr, from._arr);
+			std::swap(_ftha, from._ftha);
+		}
+	}
 
 	/*! Find an element with the given value
 	  \param what element to find

--- a/include/fix8/traits.hpp
+++ b/include/fix8/traits.hpp
@@ -209,9 +209,6 @@ struct FieldTrait_Hash_Array
    }
 
    ~FieldTrait_Hash_Array() { delete[] _arr; }
-
-   FieldTrait_Hash_Array(const FieldTrait_Hash_Array &) = delete;
-   FieldTrait_Hash_Array& operator=(const FieldTrait_Hash_Array &) = delete;
 };
 
 //-------------------------------------------------------------------------------------------------
@@ -238,11 +235,10 @@ public:
 	}
 
 private:
-	size_t _reserve = 0;
-	size_t _sz = 0;
-	size_t _rsz = 0;
-	FieldTrait *_arr = nullptr;
-	const FieldTrait_Hash_Array *_ftha = nullptr;
+	size_t _reserve;
+	size_t _sz, _rsz;
+	FieldTrait *_arr;
+	const FieldTrait_Hash_Array *_ftha;
 
 	using internal_result = std::pair<iterator, iterator>;
 	using const_internal_result = std::pair<const_iterator, const_iterator>;
@@ -253,49 +249,31 @@ public:
 	  \param sz number of elements in set to copy
 	  \param ftha pointer to field hash array */
 	presorted_set(const_iterator arr_start, const size_t sz, const FieldTrait_Hash_Array *ftha)
-		: _sz(sz), _arr(new FieldTrait[_sz]), _ftha(ftha)
+		: _reserve(), _sz(sz), _arr(new FieldTrait[_sz]), _ftha(ftha)
 			{ memcpy(_arr, arr_start, _sz * sizeof(FieldTrait)); }
 
 	/*! ctor - initialise an empty set; defer memory allocation;
 	  \param arr_start pointer to start of static array to copy elements from
 	  \param sz number of elements to initially allocate
 	  \param reserve percentage of sz to keep in reserve */
-	presorted_set(const_iterator arr_start, const size_t sz, const size_t reserve=FIX8_RESERVE_PERCENT)
-		: _reserve(reserve), _sz(sz), _rsz(_sz + calc_reserve(_sz, _reserve)), _arr(new FieldTrait[_rsz])
+	presorted_set(const_iterator arr_start, const size_t sz, const size_t reserve=FIX8_RESERVE_PERCENT) : _reserve(reserve),
+		_sz(sz), _rsz(_sz + calc_reserve(_sz, _reserve)), _arr(new FieldTrait[_rsz]), _ftha()
 			{ memcpy(_arr, arr_start, _sz * sizeof(FieldTrait)); }
 
 	/*! copy ctor
 	  \param from presorted_set object to copy */
-	presorted_set(const presorted_set& from)
-		: _reserve(from._reserve), _sz(from._sz), _rsz(from._rsz), _arr(new FieldTrait[_rsz]), _ftha(from._ftha)
+	presorted_set(const presorted_set& from) : _reserve(from._reserve),
+		_sz(from._sz), _rsz(from._rsz), _arr(new FieldTrait[_rsz]), _ftha(from._ftha)
 			{ memcpy(_arr, from._arr, _sz * sizeof(FieldTrait)); }
 
 	/*! ctor - initialise an empty set; defer memory allocation;
 	  \param sz number of elements to initially allocate
 	  \param reserve percentage of sz to keep in reserve */
-	explicit presorted_set(const size_t sz=0, const size_t reserve=FIX8_RESERVE_PERCENT)
-		: _reserve(reserve), _sz(sz), _rsz(_sz + calc_reserve(_sz, _reserve)) {}
+	explicit presorted_set(const size_t sz=0, const size_t reserve=FIX8_RESERVE_PERCENT) : _reserve(reserve),
+		_sz(sz), _rsz(_sz + calc_reserve(_sz, _reserve)), _arr(), _ftha() {}
 
 	/// dtor
 	~presorted_set() { delete[] _arr; }
-
-	presorted_set& operator=(const presorted_set& from) {
-		if (this != &from) {
-			presorted_set tmp(from);
-			swap(tmp);
-		}
-		return *this;
-	}
-
-	void swap(presorted_set& from) {
-		if (this != &from) {
-			std::swap(_reserve, from._reserve);
-			std::swap(_sz, from._sz);
-			std::swap(_rsz, from._rsz);
-			std::swap(_arr, from._arr);
-			std::swap(_ftha, from._ftha);
-		}
-	}
 
 	/*! Find an element with the given value
 	  \param what element to find

--- a/runtime/configuration.cpp
+++ b/runtime/configuration.cpp
@@ -300,8 +300,8 @@ Logger *Configuration::create_logger(const XmlElement *from, const Logtype ltype
 
 				get_logname(which, logname, sid); // only applies to file loggers
 				if (flags & Logger::xml)
-					return new XmlFileLogger(logname, flags, levels, delim, positions, get_logfile_rotation(which));
-				return new FileLogger(logname, flags, levels, delim, positions, get_logfile_rotation(which));
+					return new XmlFileLogger(logname, flags, levels, delim, positions, get_logfile_rotation(which), get_logfile_rotation_size(which));
+				return new FileLogger(logname, flags, levels, delim, positions, get_logfile_rotation(which), get_logfile_rotation_size(which));
 			}
 		}
 	}

--- a/runtime/connection.cpp
+++ b/runtime/connection.cpp
@@ -316,7 +316,7 @@ void Connection::stop()
 {
 	scout_debug << "Connection::stop()";
 	try {
-		_reader.socket()->shutdownReceive();
+		_reader.socket()->shutdown();
 	} catch(const Poco::Net::NetException& ex) {
 		scout_warn << "Connection::stop() msg:" << ex.displayText();
 		_session.do_state_change(States::st_session_terminated);

--- a/runtime/connection.cpp
+++ b/runtime/connection.cpp
@@ -315,16 +315,16 @@ void Connection::start()
 void Connection::stop()
 {
 	scout_debug << "Connection::stop()";
-	_writer.stop();
-	_writer.join();
-	_reader.stop();
-	_reader.join();
 	try {
 		_reader.socket()->shutdownReceive();
 	} catch(const Poco::Net::NetException& ex) {
 		scout_warn << "Connection::stop() msg:" << ex.displayText();
 		_session.do_state_change(States::st_session_terminated);
 	}
+	_writer.stop();
+	_reader.stop();
+	_writer.join();
+	_reader.join();
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/runtime/connection.cpp
+++ b/runtime/connection.cpp
@@ -319,7 +319,12 @@ void Connection::stop()
 	_writer.join();
 	_reader.stop();
 	_reader.join();
-	_reader.socket()->shutdownReceive();
+	try {
+		_reader.socket()->shutdownReceive();
+	} catch(const Poco::Net::NetException& ex) {
+		scout_warn << "Connection::stop() msg:" << ex.displayText();
+		_session.do_state_change(States::st_session_terminated);
+	}
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/runtime/connection.cpp
+++ b/runtime/connection.cpp
@@ -268,7 +268,7 @@ int FIXWriter::execute(f8_thread_cancellation_token& cancellation_token)
 	int result(0), processed(0), invalid(0);
 
 	while (!cancellation_token && !_session.is_shutdown())
-   {
+	{
 		try
 		{
 			Message *inmsg(0);
@@ -315,16 +315,16 @@ void Connection::start()
 void Connection::stop()
 {
 	scout_debug << "Connection::stop()";
-	_writer.stop();
-	_writer.join();
-	_reader.stop();
-	_reader.join();
 	try {
 		_reader.socket()->shutdownReceive();
 	} catch(const Poco::Net::NetException& ex) {
 		scout_warn << "Connection::stop() msg:" << ex.displayText();
 		_session.do_state_change(States::st_session_terminated);
 	}
+	_writer.stop();
+	_reader.stop();
+	_writer.join();
+	_reader.join();
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/runtime/connection.cpp
+++ b/runtime/connection.cpp
@@ -268,7 +268,7 @@ int FIXWriter::execute(f8_thread_cancellation_token& cancellation_token)
 	int result(0), processed(0), invalid(0);
 
 	while (!cancellation_token && !_session.is_shutdown())
-	{
+   {
 		try
 		{
 			Message *inmsg(0);
@@ -315,16 +315,16 @@ void Connection::start()
 void Connection::stop()
 {
 	scout_debug << "Connection::stop()";
+	_writer.stop();
+	_writer.join();
+	_reader.stop();
+	_reader.join();
 	try {
 		_reader.socket()->shutdownReceive();
 	} catch(const Poco::Net::NetException& ex) {
 		scout_warn << "Connection::stop() msg:" << ex.displayText();
 		_session.do_state_change(States::st_session_terminated);
 	}
-	_writer.stop();
-	_reader.stop();
-	_writer.join();
-	_reader.join();
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/runtime/logger.cpp
+++ b/runtime/logger.cpp
@@ -313,13 +313,20 @@ bool FileLogger::rotate(bool force)
 
 void FileLogger::process_logline(LogElement *msg_ptr)
 {
-	{
-		f8_scoped_lock guard(_rotsize_mutex);
-		if (_ofs && get_rotate_size() < _ofs->tellp())
+	if (get_rotate_size() < get_current_file_size()) {
 			rotate(true);
 	}
 
 	Logger::process_logline(msg_ptr);
+}
+
+void FileLogger::get_current_file_size() const {
+	f8_scoped_lock guard(_mutex);
+	if(_ofs) {
+		return _ofs->tellp();
+	} else {
+		return 0;
+	}
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -381,10 +388,8 @@ BCLogger::BCLogger(const string& ip, const unsigned port, const LogFlags flags, 
 //-------------------------------------------------------------------------------------------------
 void XmlFileLogger::process_logline(LogElement *msg_ptr)
 {
-	{
-		f8_scoped_lock guard(_rotsize_mutex);
-		if (_ofs && get_rotate_size() < _ofs->tellp())
-			rotate(true);
+	if (get_rotate_size() < get_current_file_size()) {
+		rotate(true);
 	}
 
 	f8String spacer(3, ' ');

--- a/runtime/session.cpp
+++ b/runtime/session.cpp
@@ -964,7 +964,7 @@ bool Session::send_raw_process(const std::function<std::size_t(const Header&)>& 
 
 		auto size = encode(header);
 
-		if (!_connection->send(buffer, size)) {
+		if (!_connection || !_connection->send(buffer, size)) {
 			slout_error << "Message write failed: " << size << " bytes";
 			return false;
 		}
@@ -1053,7 +1053,7 @@ bool Session::send_process(Message *msg) // called from the connection (possibly
 				ptr = &_batchmsgs_buffer[0];
 				enclen = _batchmsgs_buffer.size();
 			}
-			if (!_connection->send(ptr, enclen))
+			if (!_connection || !_connection->send(ptr, enclen))
 			{
 				slout_error << "Message write failed: " << enclen << " bytes";
 				_batchmsgs_buffer.clear();

--- a/runtime/session.cpp
+++ b/runtime/session.cpp
@@ -932,6 +932,9 @@ bool Session::send(Message& tosend, const unsigned custom_seqnum, const bool no_
 //-------------------------------------------------------------------------------------------------
 size_t Session::send_batch(const vector<Message *>& msgs, bool destroy)
 {
+        if(!_connection) {
+            return 0;
+        }
 	return _connection->write_batch(msgs, destroy);
 }
 
@@ -943,7 +946,7 @@ int Session::modify_header(MessageBase *msg)
 
 bool Session::send_raw(std::function<std::size_t(const Header&)> encode, char* buffer)
 {
-    return _connection->write_raw(encode, buffer);
+    return _connection && _connection->write_raw(encode, buffer);
 }
 
 bool Session::send_raw_process(std::function<std::size_t(const Header&)> encode, const char* buffer)

--- a/runtime/session.cpp
+++ b/runtime/session.cpp
@@ -956,22 +956,24 @@ bool Session::send_raw_process(std::function<std::size_t(const Header&)> encode,
         char sending_time_buffer[64];
         sending_time_buffer[date_time_format(Tickval(true), sending_time_buffer, _with_ms)] = '\0';
 
-        slout_debug << "send_raw_process: _next_send_seq = " << _next_send_seq;
-        Header header{"FIXT.1.1",
+        Header header{_sid.get_beginString().get().data(),
                       _sid.get_senderCompID().get().data(),
                       _sid.get_targetCompID().get().data(),
                       sending_time_buffer,
                       _next_send_seq};
 
         auto size = encode(header);
-        slout_debug << "Sending:" << buffer;
+
         if (!_connection->send(buffer, size)) {
             slout_error << "Message write failed: " << size << " bytes";
             return false;
         }
 
+        if (_plogger && _plogger->has_flag(Logger::outbound)) {
+            plog(buffer, Logger::Info);
+        }
+
         ++_next_send_seq;
-        return true;
     }
     catch (f8Exception& e)
     {
@@ -983,8 +985,7 @@ bool Session::send_raw_process(std::function<std::size_t(const Header&)> encode,
         slout_error << e.displayText();
         return false;
     }
-
-    return true;
+	return true;
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/runtime/session.cpp
+++ b/runtime/session.cpp
@@ -944,47 +944,47 @@ int Session::modify_header(MessageBase *msg)
 	return 0;
 }
 
-bool Session::send_raw(std::function<std::size_t(const Header&)> encode, char* buffer)
+bool Session::send_raw(const std::function<std::size_t(const Header&)>& encode, char* buffer)
 {
-    return _connection && _connection->write_raw(encode, buffer);
+	return _connection && _connection->write_raw(encode, buffer);
 }
 
-bool Session::send_raw_process(std::function<std::size_t(const Header&)> encode, const char* buffer)
+bool Session::send_raw_process(const std::function<std::size_t(const Header&)>& encode, const char* buffer)
 {
-    try
-    {
-        char sending_time_buffer[64];
-        sending_time_buffer[date_time_format(Tickval(true), sending_time_buffer, _with_ms)] = '\0';
+	try
+	{
+		char sending_time_buffer[32];
+		sending_time_buffer[date_time_format(Tickval(true), sending_time_buffer, _with_ms)] = '\0';
 
-        Header header{_sid.get_beginString().get().data(),
-                      _sid.get_senderCompID().get().data(),
-                      _sid.get_targetCompID().get().data(),
-                      sending_time_buffer,
-                      _next_send_seq};
+		Header header{_sid.get_beginString().get().data(),
+					  _sid.get_senderCompID().get().data(),
+					  _sid.get_targetCompID().get().data(),
+					  sending_time_buffer,
+					  _next_send_seq};
 
-        auto size = encode(header);
+		auto size = encode(header);
 
-        if (!_connection->send(buffer, size)) {
-            slout_error << "Message write failed: " << size << " bytes";
-            return false;
-        }
+		if (!_connection->send(buffer, size)) {
+			slout_error << "Message write failed: " << size << " bytes";
+			return false;
+		}
 
-        if (_plogger && _plogger->has_flag(Logger::outbound)) {
-            plog(buffer, Logger::Info);
-        }
+		if (_plogger && _plogger->has_flag(Logger::outbound)) {
+			plog(buffer, Logger::Info);
+		}
 
-        ++_next_send_seq;
-    }
-    catch (f8Exception& e)
-    {
-        slout_error << e.what();
-        return false;
-    }
-    catch (Poco::Exception& e)
-    {
-        slout_error << e.displayText();
-        return false;
-    }
+		++_next_send_seq;
+	}
+	catch (f8Exception& e)
+	{
+		slout_error << e.what();
+		return false;
+	}
+	catch (Poco::Exception& e)
+	{
+		slout_error << e.displayText();
+		return false;
+	}
 	return true;
 }
 

--- a/runtime/session.cpp
+++ b/runtime/session.cpp
@@ -941,20 +941,47 @@ int Session::modify_header(MessageBase *msg)
 	return 0;
 }
 
-bool Session::send_raw(std::function<std::size_t(const Header&, const char*)> encode, char* buffer) {
-	return _connection->write_raw(encode, buffer);
+bool Session::send_raw(std::function<std::size_t(const Header&)> encode, char* buffer)
+{
+    return _connection->write_raw(encode, buffer);
 }
 
-bool Session::send_raw_process(std::function<std::size_t(const Header&, const char*)> encode, const char* buffer) {
-	char sending_time_buffer[64];
-	sending_time_buffer[date_time_format(Tickval(true), sending_time_buffer, _with_ms)] = '\0';
-    Header header{"FIXT.1.1",
-                  _sid.get_senderCompID().get().data(),
-                  _sid.get_targetCompID().get().data(),
-                  sending_time_buffer,
-                  _next_send_seq++};
-	auto size = encode(header, buffer);
-	return _connection->send(buffer, size);
+bool Session::send_raw_process(std::function<std::size_t(const Header&)> encode, const char* buffer)
+{
+    try
+    {
+        char sending_time_buffer[64];
+        sending_time_buffer[date_time_format(Tickval(true), sending_time_buffer, _with_ms)] = '\0';
+
+        slout_debug << "send_raw_process: _next_send_seq = " << _next_send_seq;
+        Header header{"FIXT.1.1",
+                      _sid.get_senderCompID().get().data(),
+                      _sid.get_targetCompID().get().data(),
+                      sending_time_buffer,
+                      _next_send_seq};
+
+        auto size = encode(header);
+        slout_debug << "Sending:" << buffer;
+        if (!_connection->send(buffer, size)) {
+            slout_error << "Message write failed: " << size << " bytes";
+            return false;
+        }
+
+        ++_next_send_seq;
+        return true;
+    }
+    catch (f8Exception& e)
+    {
+        slout_error << e.what();
+        return false;
+    }
+    catch (Poco::Exception& e)
+    {
+        slout_error << e.displayText();
+        return false;
+    }
+
+    return true;
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/runtime/xml.cpp
+++ b/runtime/xml.cpp
@@ -137,6 +137,11 @@ bool exec_cmd(const string& cmd, string& result)
    return !result.empty();
 }
 
+int generateNextNodeSequence() {
+    static std::atomic_int sequence{};
+    return ++sequence;
+}
+
 }
 
 //-----------------------------------------------------------------------------------------
@@ -144,7 +149,7 @@ bool exec_cmd(const string& cmd, string& result)
 //-----------------------------------------------------------------------------------------
 XmlElement::XmlElement(istream& ifs, int subidx, XmlElement *parent, int txtline, int depth, const char *rootAttr)
 	: parent_(parent), root_(parent_ ? parent_->root_ : this), errors_(), line_(1), incline_(1), maxdepth_(),
-	seq_(), value_(), decl_(), depth_(depth), sequence_(++root_->seq_), txtline_(txtline),
+	seq_(), value_(), decl_(), depth_(depth), sequence_(generateNextNodeSequence()), txtline_(txtline),
 	chldcnt_(), subidx_(subidx), attrs_(), children_(), _was_include(), ordchildren_()
 {
 	istream *ifsptr(&ifs);


### PR DESCRIPTION
UTCTimeStamp fields are defined to have microseconds or no fractions of seconds.
We need to support the decoding of timestamps with microseconds.